### PR TITLE
Integrate Foundation

### DIFF
--- a/stash/.meteor/packages
+++ b/stash/.meteor/packages
@@ -7,3 +7,5 @@
 meteor-platform
 autopublish
 insecure
+matthew:foundation5-sass
+foundation

--- a/stash/.meteor/versions
+++ b/stash/.meteor/versions
@@ -13,6 +13,8 @@ deps@1.0.6
 ejson@1.0.5
 fastclick@1.0.2
 follower-livedata@1.0.3
+foundation@0.0.0
+fourseven:scss@1.0.0
 geojson-utils@1.0.2
 html-tools@1.0.3
 htmljs@1.0.3
@@ -24,6 +26,7 @@ json@1.0.2
 launch-screen@1.0.1
 livedata@1.0.12
 logging@1.0.6
+matthew:foundation5-sass@1.0.0
 meteor@1.1.4
 meteor-platform@1.2.1
 minifiers@1.1.3

--- a/stash/packages/.gitignore
+++ b/stash/packages/.gitignore
@@ -1,0 +1,1 @@
+/foundation

--- a/stash/smart.json
+++ b/stash/smart.json
@@ -1,0 +1,5 @@
+{
+  "packages": {
+    "foundation": {}
+  }
+}

--- a/stash/smart.lock
+++ b/stash/smart.lock
@@ -1,0 +1,15 @@
+{
+  "meteor": {},
+  "dependencies": {
+    "basePackages": {
+      "foundation": {}
+    },
+    "packages": {
+      "foundation": {
+        "git": "https://github.com/ewall/meteor-foundation.git",
+        "tag": "v5.4.0",
+        "commit": "19b30241d4dfc8899163c6c15f79ab79bf11f959"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## How to install
1. `npm install -g meteorite` or `sudo -H npm install -g meteorite`
2. `mrt add foundation`
3. Minified CSS and JS files will be linked in your client-side code.
4. Foundation's JavaScripts are already initialized in your client.
